### PR TITLE
Recover has non-lazy evaluated option

### DIFF
--- a/Monads.NET/Maybe.cs
+++ b/Monads.NET/Maybe.cs
@@ -175,6 +175,19 @@ namespace Monads.NET
         }
 
         /// <summary>
+        /// Allows for a an alternative value to be used when an object is null.   
+        /// </summary>
+        /// <typeparam name="TInput">type of object to extend</typeparam>
+        /// <param name="o">object to be extended</param>
+        /// <param name="recover">value that will be used if o is null</param>
+        /// <returns></returns>
+        public static TInput Recover<TInput>(this TInput o, TInput recover)
+            where TInput : class
+        {
+            return o ?? recover;
+        }
+
+        /// <summary>
         /// Allows for a function to run on an object when it is not null otherwise returns a default value.
         /// </summary>
         /// <typeparam name="TInput">type of object to be extended</typeparam>

--- a/Monads.Net.Tests/MaybeTests.cs
+++ b/Monads.Net.Tests/MaybeTests.cs
@@ -262,6 +262,20 @@ namespace Monads.Net.Tests
             Assert.AreEqual(did, true);
             Assert.AreEqual(didAgain, false);
         }
+
+		[TestMethod]
+		public void Recover_uses_value_when_null()
+		{
+		    string val = null;
+		    Assert.AreEqual(val.Recover("a"), "a");
+		}
+
+		[TestMethod]
+		public void Recover_does_not_use_value_when_not_null()
+		{
+		    string val = "a";
+		    Assert.AreEqual(val.Recover("b"), "a");
+		}
 	}
 
 	public class TestableDummy


### PR DESCRIPTION
Adding a non-lazily evaluated option to Recover. This is so that I can write:

```
x.Recover("A");
```

Instead of

```
x.Recover(() => "A");
```

when there is no extra cost associated with evaluating the recovery option.
